### PR TITLE
Resolving the error "TypeError: Object #<Query> has no method 'run'"

### DIFF
--- a/lib/relationships.js
+++ b/lib/relationships.js
@@ -317,7 +317,7 @@ MongooseArray.prototype.populate = function(fields, callback) {
   return model
     .findById(parent._id)
     .populate(path, fields)
-    .run(callback);
+    .exec(callback);
 };
 
 


### PR DESCRIPTION
On call model.submodel.populate() throws this error. It seems that the method `run` was deplicated.

`TypeError: Object #<Query> has no method 'run'
    at Array.MongooseArray.populate (/home/user/dev/nodejs/marqet-express/node_modules/mongo-relation/lib/relationships.js:320:6)`
