### PR TITLE
setParent option to prevent adding child ids to parent documents in hasMany

### DIFF
--- a/Todo.md
+++ b/Todo.md
@@ -5,3 +5,52 @@ HasMany should not set the id on the parent document
     tweet = user.tweets.build();
     user.tweets.should.eql([]);
     tweet.user.should.eql user._id;
+
+
+
+#### hasOne
+
+User hasOne Profile
+
+Use case: A required relationship - A user would not make sense without a profile. Every user must have one.
+
+| User       | Profile |
+|------------|---------|
+| profile_id | id      |
+
+plus unique index on Profile.user_id
+
+    user.profile.age
+
+#### hasMany
+
+User hasMany Profiles
+
+| User | Profile |
+|------|---------|
+| id   | user_id |
+
+    user.profiles.first.age
+
+#### belongsTo
+
+Profile belongsTo User
+
+Use case: A profile does not make sense without the user. Orphaned objects shouldn't exist.
+
+| User       | Profile |
+|------------|---------|
+| id         | user_id |
+
+    profile.user.id
+
+#### hasAndBelongsToMany
+
+User hasMany profiles, profiles hasMany users
+
+| User        | Profile  |
+|-------------|----------|
+| profile_ids | user_ids |
+
+    user.profiles.first.id
+    profile.users.first.id

--- a/lib/relationships.js
+++ b/lib/relationships.js
@@ -32,6 +32,10 @@ Schema.prototype._addRelationship = function (type, model, options) {
   this.paths[pathName].options[type] = model;
   if (options && options.dependent)
     this.paths[pathName].options.dependent = options.dependent;
+  this.paths[pathName].options.setParent = true
+  if(type == 'hasMany' && options){
+    this.paths[pathName].options.setParent = options.hasOwnProperty('setParent') ? options.setParent : true;
+  }
   return this;
 };
 /**
@@ -132,7 +136,7 @@ MongooseArray.prototype._getRelationship = function () {
 MongooseArray.prototype.build = function (objs) {
   if (!this._hasRelationship())
     throw new Error('Path doesn\'t contain a reference');
-  var self = this, parent = this._parent, childModelName = this._schema.options.hasMany || this._schema.options.habtm, childModel = parent.model(childModelName), childSchema = childModel.schema, parentModelName = parent.constructor.modelName, childPath = childSchema._findPathReferencing(parentModelName);
+  var setParent = this._schema.options.setParent, self = this, parent = this._parent, childModelName = this._schema.options.hasMany || this._schema.options.habtm, childModel = parent.model(childModelName), childSchema = childModel.schema, parentModelName = parent.constructor.modelName, childPath = childSchema._findPathReferencing(parentModelName);
   var build = function (obj) {
     obj = new childModel(obj);
     // HABTM or belongsTo?
@@ -140,7 +144,8 @@ MongooseArray.prototype.build = function (objs) {
       obj[childPath.name].push(parent);
     else
       obj[childPath.name] = parent;
-    parent[self._path].push(obj);
+    if (setParent)
+      parent[self._path].push(obj);
     return obj;
   };
   if (Array.isArray(objs)) {
@@ -220,18 +225,16 @@ MongooseArray.prototype.find = function (conditions, fields, options, callback) 
   } else if ('function' == typeof options) {
     callback = options;
     options = null;
-  } else {
-    conditions = {};
   }
-  var parent = this._parent, childModel = parent.model(this._schema.options.hasMany || this._schema.options.habtm), childPath = childModel.schema._findPathReferencing(parent.constructor.modelName);
+  var setParent = this._schema.options.setParent, parent = this._parent, childModel = parent.model(this._schema.options.hasMany || this._schema.options.habtm), childPath = childModel.schema._findPathReferencing(parent.constructor.modelName);
   // You *need* a reference in the child `Document`
   if (!childPath)
     throw new Error('Parent model not referenced anywhere in the Child Schema');
   var safeConditions = {};
   safeConditions[childPath.name] = parent._id;
   merge(safeConditions, conditions);
-  merge(safeConditions, { _id: { $in: parent[this._path] } });
-  //var query = new mongoose.Query(safeConditions, options).select(fields).bind(childModel, 'find');
+  if(setParent)
+    merge(safeConditions, { _id: { $in: parent[this._path] } });
   var query = childModel.find(safeConditions, options).select(fields);
   if ('undefined' === typeof callback)
     return query;
@@ -250,7 +253,9 @@ MongooseArray.prototype.populate = function (fields, callback) {
     callback = fields;
     fields = null;
   }
-  var parent = this._parent, model = parent.constructor, path = this._path, self = this;
+  var setParent = this._schema.options.setParent, parent = this._parent, model = parent.constructor, path = this._path;
+  if(!setParent)
+    return callback(new Error('Cannot populate when setParent is false. Use #find.'));
   return model.findById(parent._id).populate(path, fields).exec(callback);
 };
 /**
@@ -357,7 +362,7 @@ MongooseArray.prototype.append = function (child, callback) {
   };
   if (!this._hasRelationship())
     return throwErr('Path doesn\'t contain a reference');
-  var relationship = this._getRelationship();
+  var setParent = this._schema.options.setParent, relationship = this._getRelationship();
   if (child.constructor.modelName !== relationship.ref)
     return throwErr('Wrong Model type');
   var childPath = child.schema._findPathReferencing(this._parent.constructor.modelName);
@@ -365,7 +370,8 @@ MongooseArray.prototype.append = function (child, callback) {
     child[childPath.name].push(this._parent._id);
   else
     child[childPath.name] = this._parent._id;
-  this._parent[this._path].push(child._id);
+  if(setParent)
+    this._parent[this._path].push(child._id);
   if (!callback)
     return child;
   return child.save(callback);

--- a/specs/hasAndBelongsToMany.spec.js
+++ b/specs/hasAndBelongsToMany.spec.js
@@ -16,6 +16,16 @@ describe('hasManyBelongsToMany', function() {
     Post.schema.paths['categories'].options.habtm.should.equal('Category');
   });
 
+  it('does not allow setParent to be manually set', function() {
+    var ItemSchema  = new mongoose.Schema({})
+    var ThingSchema = new mongoose.Schema({})
+    ItemSchema.habtm('Thing', { setParent: false })
+    ThingSchema.habtm('Item', { setParent: true  })
+
+    ItemSchema.paths['things'].options.setParent.should.be.true
+    ThingSchema.paths['items'].options.setParent.should.be.true
+  });
+
   it('test presence of added methods to the MongooseArray', function() {
     var category = new Category(),
         post     = new Post();

--- a/specs/hasMany.spec.js
+++ b/specs/hasMany.spec.js
@@ -1,223 +1,491 @@
 require('./spec_helper');
 
-var mongoose = require('mongoose'),
-    should   = require('should'),
-    User     = require('./support/userModel'),
-    Tweet    = require('./support/tweetModel'),
-    Tag      = require('./support/tagModel');
+var mongoose     = require('mongoose'),
+    should       = require('should'),
+    User         = require('./support/userModel'),
+    Tweet        = require('./support/tweetModel'),
+    Tag          = require('./support/tagModel'),
+    Address      = require('./support/addressModel'),
+    Notification = require('./support/notificationModel');
 
 describe('hasMany', function() {
-  it('has hasMany on the path', function() {
-    User.schema.paths.tweets.options.hasMany.should.equal('Tweet');
-  });
+  describe('setup', function(){
+    it('has hasMany on the path', function() {
+      User.schema.paths.tweets.options.hasMany.should.equal('Tweet');
+    });
 
-  it('instantiates one child document', function() {
-    var user  = new User({}),
-        tweet = { title: 'Easy relationships with mongoose-relationships' };
+    it('defaults setParent to true', function() {
+      User.schema.paths.tweets.options.setParent.should.be.true
+    });
 
-    var built = user.tweets.build(tweet);
-
-    built.should.be.an.instanceof(Tweet);
-    built.author.should.eql(user._id);
-    built.title.should.equal('Easy relationships with mongoose-relationships')
-
-    user.tweets.should.have.length(1);
-  });
-
-  it('instantiates many children documents', function(done) {
-    var user   = new User(),
-        tweets = [{}, {}];
-
-    var built = user.tweets.build(tweets);
-
-    user.tweets.should.have.length(2);
-
-    var count = built.length;
-    built.forEach(function(tweet){
-      tweet.should.be.an.instanceof(Tweet);
-      tweet.author.should.eql(user._id);
-      --count || done();
+    it('sets setParent on the path', function() {
+      User.schema.paths.notifications.options.setParent.should.be.false
     });
   });
 
-  it('appendes an instantiated child document', function(done) {
-    var user  = new User(),
-        tweet = new Tweet();
+  describe('Child Relationship', function(){
+    it('instantiates one child document', function() {
+      var user  = new User({}),
+          tweet = { title: 'Easy relationships with mongoose-relationships' };
 
-    user.tweets.append(tweet, function(err, tweet) {
-      should.strictEqual(err, null);
-      tweet.author.should.eql(user._id);
-      user.tweets.should.containEql(tweet._id);
-      done();
+      var built = user.tweets.build(tweet);
+
+      built.should.be.an.instanceof(Tweet);
+      built.author.should.eql(user._id);
+      built.title.should.equal('Easy relationships with mongoose-relationships')
+
+      user.tweets.should.have.length(1);
     });
-  });
 
-  it('concates many instantiated child documents', function(done) {
-    var user   = new User(),
-        tweets = [ new Tweet(), new Tweet() ];
+    it('instantiates many children documents', function(done) {
+      var user   = new User(),
+          tweets = [{}, {}];
 
-    user.tweets.concat(tweets, function(err, tweets) {
-      should.strictEqual(err, null);
+      var built = user.tweets.build(tweets);
 
-      var count = tweets.length;
-      tweets.forEach(function(tweet){
+      user.tweets.should.have.length(2);
+
+      var count = built.length;
+      built.forEach(function(tweet){
+        tweet.should.be.an.instanceof(Tweet);
         tweet.author.should.eql(user._id);
-        user.tweets.should.containEql(tweet._id);
         --count || done();
       });
     });
   });
 
-  it('creates one child document', function(done) {
-    var user  = new User(),
-        tweet = { title: 'Easy relationships with mongoose-relationships' };
+  describe('Parent Relationship', function(){
+    it('creates one child document', function(done) {
+      var user  = new User(),
+          tweet = { title: 'Easy relationships with mongoose-relationships' };
 
-    user.tweets.create(tweet, function(err, user, tweet) {
-      should.strictEqual(err, null);
-
-      user.should.be.an.instanceof(User);
-      user.tweets.should.have.length(1);
-      user.tweets[0].should.equal(tweet._id);
-
-      tweet.should.be.an.instanceof(Tweet);
-      tweet.title.should.equal('Easy relationships with mongoose-relationships')
-      tweet.author.should.equal(user._id);
-      done();
-    });
-  });
-
-  it('creates many children documents', function(done) {
-    var user = new User(),
-        tweets = [ { title: 'Blog tweet #1' },
-                   { title: 'Blog tweet #2' } ];
-
-    user.tweets.create(tweets, function(err, user, tweets) {
-      should.strictEqual(err, null);
-
-      user.tweets.should.have.length(2);
-      tweets.should.have.length(2);
-
-      var count = tweets.length;
-      tweets.forEach(function(tweet) {
-        user.tweets.should.containEql(tweet._id)
-        tweet.should.be.an.instanceof(Tweet);
-        tweet.author.should.equal(user._id);
-        --count || done()
-      });
-    });
-  });
-
-  it('finds children documents', function(done) {
-    var user   = new User(),
-        tweets = [ { title: 'Blog tweet #1' },
-                   { title: 'Blog tweet #2' } ]
-
-    user.tweets.create(tweets, function(err, user, tweets) {
-      var find = user.tweets.find({}, function(err, newTweets) {
+      user.tweets.create(tweet, function(err, user, tweet) {
         should.strictEqual(err, null);
 
-        find.should.be.an.instanceof(mongoose.Query);
-        find._conditions.should.have.property('_id');
-        find._conditions.should.have.property('author');
-        find._conditions._id['$in'].should.be.an.instanceof(Array);
+        user.should.be.an.instanceof(User);
+        user.tweets.should.have.length(1);
+        user.tweets[0].should.equal(tweet._id);
 
-        var search = function() {
-          find.find({ title: 'Blog tweet #1' }, function(err, otherTweets) {
-            find._conditions.title.should.equal('Blog tweet #1');
-            find._conditions.should.have.property('_id');
+        tweet.should.be.an.instanceof(Tweet);
+        tweet.title.should.equal('Easy relationships with mongoose-relationships')
+        tweet.author.should.equal(user._id);
+        done();
+      });
+    });
 
-            otherTweets.should.have.length(1);
-            otherTweets[0].title.should.equal('Blog tweet #1');
-            done();
-          });
-        };
+    it('appends one instantiated child document', function(done) {
+      var user  = new User(),
+          tweet = new Tweet();
 
-        newTweets.should.have.length(2);
+      user.tweets.append(tweet, function(err, tweet) {
+        should.strictEqual(err, null);
+        tweet.author.should.eql(user._id);
+        user.tweets.should.containEql(tweet._id);
+        done();
+      });
 
-        var count = newTweets.length;
-        newTweets.forEach(function(tweet) {
+    });
+
+    it('concates many instantiated child documents', function(done) {
+      var user   = new User(),
+          tweets = [ new Tweet(), new Tweet() ];
+
+      user.tweets.concat(tweets, function(err, tweets) {
+        should.strictEqual(err, null);
+
+        var count = tweets.length;
+        tweets.forEach(function(tweet){
+          tweet.author.should.eql(user._id);
+          user.tweets.should.containEql(tweet._id);
+          --count || done();
+        });
+      });
+    });
+
+    it('creates many children documents', function(done) {
+      var user = new User(),
+          tweets = [ { title: 'Blog tweet #1' },
+                     { title: 'Blog tweet #2' } ];
+
+      user.tweets.create(tweets, function(err, user, tweets) {
+        should.strictEqual(err, null);
+
+        user.tweets.should.have.length(2);
+        tweets.should.have.length(2);
+
+        var count = tweets.length;
+        tweets.forEach(function(tweet) {
           user.tweets.should.containEql(tweet._id)
           tweet.should.be.an.instanceof(Tweet);
-          tweet.author.should.eql(user._id);
-          --count || search();
+          tweet.author.should.equal(user._id);
+          --count || done()
         });
       });
     });
-  });
 
-  it('deletes dependents', function(done) {
-    var user   = new User(),
-        tweets = [ { title: 'Blog tweet #1' },
-                   { title: 'Blog tweet #2' } ];
+    it('finds children documents', function(done) {
+      var user   = new User(),
+          tweets = [ { title: 'Blog tweet #1' },
+                     { title: 'Blog tweet #2' } ]
 
-    user.tweets.create(tweets, function(err, user, tweets){
-      var tweet = tweets[0];
-      user.tweets.remove(tweet._id, function(err, user){
-        should.strictEqual(err, null);
-
-        user.tweets.should.not.containEql(tweet._id);
-        user.tweets.should.have.length(1);
-
-        // Tweet, be gone!
-        Tweet.findById(tweet._id, function(err, found){
-          should.strictEqual(err, null);
-          should.not.exist(found);
-          done();
-        });
-      });
-    });
-  });
-
-  it('nullifies dependents', function(done){
-    var user = new User(),
-        tags = [ { name: 'awesome' },
-                 { name: 'omgbbq' } ];
-
-    user.tags.create(tags, function(err, user, tags){
-      var tag = tags[0];
-      user.tags.remove(tag._id, function(err, user){
-        should.strictEqual(err, null);
-
-        user.tags.should.not.containEql(tag._id);
-        user.tags.should.have.length(1);
-
-        // Tweet, be nullified!
-        Tag.findById(tag._id, function(err, tag){
-          should.strictEqual(err, null);
-          should.not.exist(tag.user);
-          done();
-        });
-      });
-    });
-  });
-
-  it('test population of path', function(done){
-    var user   = new User(),
-        tweets = [ { title: 'Blog tweet #1' },
-                   { title: 'Blog tweet #2' } ];
-
-    user.tweets.create(tweets, function(err, user, tweets){
-      user.save(function(err, user){
-        User.findById(user._id).populate('tweets').exec(function(err, populatedUser){
+      user.tweets.create(tweets, function(err, user, tweets) {
+        var find = user.tweets.find({}, function(err, newTweets) {
           should.strictEqual(err, null);
 
-          var testSugar = function(){
-            // Syntactic sugar
-            user.tweets.populate(function(err, user){
-              should.strictEqual(err, null);
+          find.should.be.an.instanceof(mongoose.Query);
+          find._conditions.should.have.property('_id');
+          find._conditions.should.have.property('author');
+          find._conditions._id['$in'].should.be.an.instanceof(Array);
 
-              var count = user.tweets.length;
-              user.tweets.forEach(function(tweet){
-                tweet.should.be.an.instanceof(Tweet);
-                --count || done();
-              });
+          var search = function() {
+            find.find({ title: 'Blog tweet #1' }, function(err, otherTweets) {
+              find._conditions.title.should.equal('Blog tweet #1');
+              find._conditions.should.have.property('_id');
+
+              otherTweets.should.have.length(1);
+              otherTweets[0].title.should.equal('Blog tweet #1');
+              done();
             });
           };
 
-          var count = populatedUser.tweets.length;
-          populatedUser.tweets.forEach(function(tweet){
+          newTweets.should.have.length(2);
+
+          var count = newTweets.length;
+          newTweets.forEach(function(tweet) {
+            user.tweets.should.containEql(tweet._id)
             tweet.should.be.an.instanceof(Tweet);
-            --count || testSugar();
+            tweet.author.should.eql(user._id);
+            --count || search();
+          });
+        });
+      });
+    });
+
+    it('deletes dependent child documents', function(done) {
+      var user   = new User(),
+          tweets = [ { title: 'Blog tweet #1' },
+                     { title: 'Blog tweet #2' } ];
+
+      user.tweets.create(tweets, function(err, user, tweets){
+        var tweet = tweets[0];
+        user.tweets.remove(tweet._id, function(err, user){
+          should.strictEqual(err, null);
+
+          user.tweets.should.not.containEql(tweet._id);
+          user.tweets.should.have.length(1);
+
+          // Tweet, be gone!
+          Tweet.findById(tweet._id, function(err, found){
+            should.strictEqual(err, null);
+            should.not.exist(found);
+            done();
+          });
+        });
+      });
+    });
+
+    it('nullifies dependent child documents', function(done){
+      var user = new User(),
+          tags = [ { name: 'awesome' },
+                   { name: 'omgbbq' } ];
+
+      user.tags.create(tags, function(err, user, tags){
+        var tag = tags[0];
+        user.tags.remove(tag._id, function(err, user){
+          should.strictEqual(err, null);
+
+          user.tags.should.not.containEql(tag._id);
+          user.tags.should.have.length(1);
+
+          // Tweet, be nullified!
+          Tag.findById(tag._id, function(err, tag){
+            should.strictEqual(err, null);
+            should.not.exist(tag.user);
+            done();
+          });
+        });
+      });
+    });
+
+    it('populates child documents in path', function(done){
+      var user   = new User(),
+          tweets = [ { title: 'Blog tweet #1' },
+                     { title: 'Blog tweet #2' } ];
+
+      user.tweets.create(tweets, function(err, user, tweets){
+        user.save(function(err, user){
+          User.findById(user._id).populate('tweets').exec(function(err, populatedUser){
+            should.strictEqual(err, null);
+
+            var testSugar = function(){
+              // Syntactic sugar
+              user.tweets.populate(function(err, user){
+                should.strictEqual(err, null);
+
+                var count = user.tweets.length;
+                user.tweets.forEach(function(tweet){
+                  tweet.should.be.an.instanceof(Tweet);
+                  --count || done();
+                });
+              });
+            };
+
+            var count = populatedUser.tweets.length;
+            populatedUser.tweets.forEach(function(tweet){
+              tweet.should.be.an.instanceof(Tweet);
+              --count || testSugar();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('Parent Relationship when setParent is false', function(){
+    describe('#create', function(){
+      it('creates one child document', function(done) {
+        var user         = new User(),
+            notification = { message: 'Check out new relationships!' };
+
+        user.notifications.create(notification, function(err, user, notification) {
+          should.strictEqual(err, null);
+
+          user.should.be.an.instanceof(User);
+          notification.should.be.an.instanceof(Notification);
+          notification.message.should.equal('Check out new relationships!')
+          notification.user.should.equal(user._id);
+          done();
+        });
+      });
+
+      it('does not add the child id to the parent', function(done) {
+        var user         = new User(),
+            notification = { message: 'Check out new relationships!' };
+
+        user.notifications.create(notification, function(err, user, notification) {
+          should.strictEqual(err, null);
+          user.notifications.should.have.length(0);
+          user.notifications.should.be.empty;
+          done();
+        });
+      });
+
+      it('creates many children documents', function(done) {
+        var user          = new User(),
+            notifications = [ { message: 'Blog notification #1' },
+                              { message: 'Blog notification #2' } ];
+
+        user.notifications.create(notifications, function(err, user, notifications) {
+          should.strictEqual(err, null);
+
+          notifications.should.have.length(2);
+
+          var count = notifications.length;
+          notifications.forEach(function(notification) {
+            notification.should.be.an.instanceof(Notification);
+            notification.user.should.equal(user._id);
+            --count || done()
+          });
+        });
+      });
+
+      it('does not add child ids to the parent', function(done) {
+        var user          = new User(),
+            notifications = [ { message: 'Blog notification #1' },
+                              { message: 'Blog notification #2' } ];
+
+        user.notifications.create(notifications, function(err, user, notifications) {
+          should.strictEqual(err, null);
+
+          user.notifications.should.have.length(0);
+          var count = notifications.length;
+          notifications.forEach(function(notification) {
+            user.notifications.should.not.containEql(notification._id)
+            --count || done()
+          });
+        });
+      });
+    });
+
+    describe('#append', function(){
+      it('associates the child to the parent', function(done) {
+        var user         = new User(),
+            notification = new Notification();
+
+        user.notifications.append(notification, function(err, notification) {
+          should.strictEqual(err, null);
+          notification.user.should.eql(user._id);
+          done();
+        });
+      });
+
+      it('does not add the child id to the parent', function(done) {
+        var user         = new User(),
+            notification = new Notification();
+
+        user.notifications.append(notification, function(err, notification) {
+          should.strictEqual(err, null);
+          user.notifications.should.be.empty;
+          done();
+        });
+      });
+    });
+
+    describe('#concat', function(){
+      it('concates many instantiated child documents', function(done) {
+        var user          = new User(),
+            notifications = [ new Notification(), new Notification() ];
+
+        user.notifications.concat(notifications, function(err, notifications) {
+          should.strictEqual(err, null);
+
+          var count = notifications.length;
+          notifications.forEach(function(notification){
+            notification.user.should.eql(user._id);
+            //user.notifications.should.containEql(notification._id);
+            --count || done();
+          });
+        });
+      });
+
+      it('does not add child ids to the parent', function(done) {
+        var user          = new User(),
+            notifications = [ new Notification(), new Notification() ];
+
+        user.notifications.concat(notifications, function(err, notifications) {
+          should.strictEqual(err, null);
+
+          var count = notifications.length;
+          notifications.forEach(function(notification){
+            user.notifications.should.not.containEql(notification._id);
+            --count || done();
+          });
+        });
+      });
+    });
+
+    describe('#find', function() {
+      it('returns a Mongoose Query', function(done) {
+        var user          = new User(),
+            notifications = [ {}, {} ]
+
+        user.notifications.create(notifications, function(err, user, notifications) {
+          var find = user.notifications.find({})
+          find.should.be.an.instanceof(mongoose.Query);
+          find._conditions.should.have.property('user');
+          done();
+        });
+      });
+
+      it('takes options to find by', function(done) {
+        var user          = new User(),
+            notifications = [ { message: 'Alert!' }, {} ]
+
+        user.notifications.create(notifications, function(err, user, notifications) {
+          var find = user.notifications.find({ message: 'Alert!' })
+          find._conditions.should.have.property('user');
+          find._conditions.should.have.property('message');
+          find._conditions.message.should.eql('Alert!');
+          done();
+        });
+      });
+
+      it('finds child documents', function(done) {
+        var user          = new User(),
+            notifications = [ {}, {} ]
+
+        user.notifications.create(notifications, function(err, user, notifications) {
+          var find = user.notifications.find({});
+          find.exec(function(err, foundNotifications) {
+            should.strictEqual(err, null);
+
+            foundNotifications.should.have.length(2);
+
+            var count = foundNotifications.length;
+            foundNotifications.forEach(function(notification) {
+              notification.should.be.an.instanceof(Notification);
+              notification.user.should.eql(user._id);
+              --count || done();
+            });
+          });
+        });
+      });
+
+      it('searching for children documents', function(done) {
+        var find,
+            user           = new User(),
+            notifications  = [ { message: 'Blog notification #1' },
+                               { message: 'Blog notification #2' } ]
+
+        user.notifications.create(notifications, function(err, user, notifications) {
+          find = user.notifications.find({ message: 'Blog notification #1' });
+          find.exec(function(err, foundNotifications) {
+            should.strictEqual(err, null);
+
+            foundNotifications.should.have.length(1);
+            foundNotifications[0].message.should.equal('Blog notification #1');
+            done();
+          });
+        });
+      });
+    });
+
+    describe('#delete', function(){
+      it('deletes dependent child documents', function(done) {
+        var user          = new User(),
+            notifications = [ { message: 'Blog tweet #1' },
+                              { message: 'Blog tweet #2' } ];
+
+        user.notifications.create(notifications, function(err, user, notifications){
+          var notification = notifications[0];
+          user.notifications.remove(notification._id, function(err, user){
+            should.strictEqual(err, null);
+
+            Notification.findById(notification._id, function(err, found){
+              should.strictEqual(err, null);
+              should.not.exist(found);
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    describe('#nullifies', function(){
+      it('nullifies dependent child documents', function(done){
+        var user      = new User(),
+            addresses = [ {}, {} ];
+
+        user.addresses.create(addresses, function(err, user, addresses){
+          var addressOne = addresses[0];
+          var addressTwo = addresses[1];
+          user.addresses.remove(addressOne._id, function(err, user){
+            should.strictEqual(err, null);
+
+            user.addresses.should.have.length(0);
+
+            Address.findById(addressOne._id, function(err, address){
+              should.strictEqual(err, null);
+              should.not.exist(address.user);
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    describe('#populate', function(){
+      it('returns an error', function(done){
+        var user          = new User(),
+            notifications = [ {}, {} ];
+
+        user.notifications.create(notifications, function(err, user, notifications){
+          user.save(function(err, user){
+            user.notifications.populate(function(err, user){
+              err.should.be.an.instanceof(Error);
+              err.message.should.eql('Cannot populate when setParent is false. Use #find.')
+              done();
+            });
           });
         });
       });

--- a/specs/spec_helper.js
+++ b/specs/spec_helper.js
@@ -10,7 +10,7 @@ var resetDb = function(next){
   });
 };
 
-beforeEach(function(done){
+before(function(done){
   if(mongoose.get('isConnected')){
     resetDb(done);
   } else {

--- a/specs/support/addressModel.js
+++ b/specs/support/addressModel.js
@@ -1,0 +1,9 @@
+var mongoose = require('mongoose');
+
+var AddressSchema = new mongoose.Schema({
+  street: String
+});
+
+AddressSchema.belongsTo('User');
+
+module.exports = mongoose.model('Address', AddressSchema);

--- a/specs/support/categoryModel.js
+++ b/specs/support/categoryModel.js
@@ -1,7 +1,7 @@
 var mongoose = require('mongoose');
 
 var CategorySchema = new mongoose.Schema({
-  title:  String
+  title: String
 });
 
 CategorySchema.belongsTo('User', { through: 'editor' });

--- a/specs/support/notificationModel.js
+++ b/specs/support/notificationModel.js
@@ -1,0 +1,9 @@
+var mongoose = require('mongoose');
+
+var NotificationSchema = new mongoose.Schema({
+  message: String
+});
+
+NotificationSchema.belongsTo('User');
+
+module.exports = mongoose.model('Notification', NotificationSchema);

--- a/specs/support/postModel.js
+++ b/specs/support/postModel.js
@@ -1,7 +1,7 @@
 var mongoose = require('mongoose');
 
 var PostSchema = new mongoose.Schema({
-  title:  String
+  title: String
 });
 
 PostSchema.belongsTo('User', { through: 'editor' });

--- a/specs/support/userModel.js
+++ b/specs/support/userModel.js
@@ -1,12 +1,13 @@
 var mongoose = require('mongoose');
 
 var UserSchema = new mongoose.Schema({
-  name:      String,
-  someArray: [ mongoose.Schema.Types.ObjectId ]
+  name: String
 });
 
-UserSchema.hasMany('Tweet', { dependent: 'delete' });
-UserSchema.hasMany('Tag',   { dependent: 'nullify'});
-UserSchema.hasOne( 'Post',  { through:   'post'   });
+UserSchema.hasMany('Tag',          { dependent: 'nullify'});
+UserSchema.hasMany('Tweet',        { dependent: 'delete' });
+UserSchema.hasOne( 'Post',         { through:   'post'   });
+UserSchema.hasMany('Notification', { setParent: false, dependent: 'delete'  });
+UserSchema.hasMany('Address',      { setParent: false, dependent: 'nullify' });
 
 module.exports = mongoose.model('User', UserSchema);


### PR DESCRIPTION
setParent option allows a `hasMany` association to not save its child ids on itself.
- mongo-relation queries children by parent's id on child as a foreign key
- Mongoose populate on a Model will not populate children
- mongoose populate on a document will return an error (use find)
- I believe we can bring `doc.populate` back eventually. Probably after we've moved to mongoose-long & our own types (instead of adding to MongooseArray.prototype)

We should discuss keeping a separate branch until the breaking changes are resolved.
