### PR TITLE
Fixes issue where mongoose insert caused infinite recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*NOTE*: I don't recommend using this at all (!!!!), however this fork has been updated to work with Mongoose 4+. This allows you to upgrade Mongo to the latest version.
+
 Mongoose Relationships [![Build Status](https://travis-ci.org/JamesS237/mongo-relation.svg?branch=master)](https://travis-ci.org/JamesS237/mongo-relation)
 ======================
 _... because sometimes embedded documents aren't enough._

--- a/lib/relationships.js
+++ b/lib/relationships.js
@@ -158,6 +158,28 @@ mongooseArrayPrototype.build = function (objs) {
  * @api public
  */
 mongooseArrayPrototype.create = function (objs, callback) {
+  // `Maximum call stack size exceeded at new ObjectID` error
+  // Seems to happen when object is inserted into mongo but is mongoose object
+  const mongooseToJSON = (o) => {
+    if (o.constructor.name === 'model') {
+      // object is mongoose object
+      return o.toJSON();
+    } else {
+      return o;
+    }
+  };
+
+  if (Array.isArray(objs)) {
+    const newObjs = [];
+    for(const o of objs) {
+      newObjs.push(mongooseToJSON(o));
+    }
+    objs = newObjs;
+  } else {
+    objs = mongooseToJSON(objs);
+  }
+
+
   if (!this._hasRelationship())
     return callback(new Error('Path doesn\'t contain a reference'));
   var self = this, parent = this._parent, childModelName = this._schema.options.hasMany || this._schema.options.habtm, childModel = parent.model(childModelName), childSchema = childModel.schema, parentModelName = parent.constructor.modelName, childPath = childSchema._findPathReferencing(parentModelName);

--- a/lib/relationships.js
+++ b/lib/relationships.js
@@ -1,4 +1,4 @@
-var mongoose = require('mongoose'), Schema = mongoose.Schema, ObjectId = Schema.ObjectId, MongooseArray = mongoose.Types.Array, utils = require('./utils'), merge = utils.merge, pluralize = utils.pluralize;
+var mongoose = require('mongoose'), Schema = mongoose.Schema, ObjectId = Schema.ObjectId, MongooseArray = mongoose.Types.Array, utils = require('./utils'), merge = utils.merge, pluralize = utils.pluralize, mongooseArrayPrototype = MongooseArray.mixin || MongooseArray.prototype;
 /**
  * Adds the relationship to the Schema's path
  * and creates the path if necessary
@@ -88,7 +88,7 @@ Schema.prototype._findPathReferencing = function (modelName, type) {
 /**
  * Check for presence of relationship
  */
-MongooseArray.prototype._hasRelationship = function () {
+mongooseArrayPrototype._hasRelationship = function () {
   return this._schema && (this._schema.options.hasMany || this._schema.options.habtm || this._schema.options.hasOne);
 };
 /**
@@ -100,7 +100,7 @@ MongooseArray.prototype._hasRelationship = function () {
  *   @param {Object} options
  * @api private
  */
-MongooseArray.prototype._getRelationship = function () {
+mongooseArrayPrototype._getRelationship = function () {
   var schemaOpts = this._schema.options, type, ref, options = {};
   if (schemaOpts.hasMany) {
     type = 'hasMany';
@@ -129,7 +129,7 @@ MongooseArray.prototype._getRelationship = function () {
  * @return {Document|Array}
  * @api public
  */
-MongooseArray.prototype.build = function (objs) {
+mongooseArrayPrototype.build = function (objs) {
   if (!this._hasRelationship())
     throw new Error('Path doesn\'t contain a reference');
   var self = this, parent = this._parent, childModelName = this._schema.options.hasMany || this._schema.options.habtm, childModel = parent.model(childModelName), childSchema = childModel.schema, parentModelName = parent.constructor.modelName, childPath = childSchema._findPathReferencing(parentModelName);
@@ -157,7 +157,7 @@ MongooseArray.prototype.build = function (objs) {
  * @param {Functions} callback [passed: (err, parent, created children)]
  * @api public
  */
-MongooseArray.prototype.create = function (objs, callback) {
+mongooseArrayPrototype.create = function (objs, callback) {
   if (!this._hasRelationship())
     return callback(new Error('Path doesn\'t contain a reference'));
   var self = this, parent = this._parent, childModelName = this._schema.options.hasMany || this._schema.options.habtm, childModel = parent.model(childModelName), childSchema = childModel.schema, parentModelName = parent.constructor.modelName, childPath = childSchema._findPathReferencing(parentModelName);
@@ -204,7 +204,7 @@ MongooseArray.prototype.create = function (objs, callback) {
  *
  * *This is a copy of Model.find w/ added error throwing and such*
  */
-MongooseArray.prototype.find = function (conditions, fields, options, callback) {
+mongooseArrayPrototype.find = function (conditions, fields, options, callback) {
   if (!this._hasRelationship())
     return callback(new Error('Path doesn\'t contain a reference'));
   // Copied from `Model.find`
@@ -245,7 +245,7 @@ MongooseArray.prototype.find = function (conditions, fields, options, callback) 
  * @return {Query}
  * @api public
  */
-MongooseArray.prototype.populate = function (fields, callback) {
+mongooseArrayPrototype.populate = function (fields, callback) {
   if ('function' == typeof fields) {
     callback = fields;
     fields = null;
@@ -262,8 +262,8 @@ MongooseArray.prototype.populate = function (fields, callback) {
  * @return {ObjectId}
  * @api public
  */
-var oldRemove = MongooseArray.prototype.remove;
-MongooseArray.prototype.remove = MongooseArray.prototype.delete = function (id, callback) {
+var oldRemove = mongooseArrayPrototype.remove;
+mongooseArrayPrototype.remove = mongooseArrayPrototype.delete = function (id, callback) {
   var args = arguments, relationship = this._getRelationship();
   if (id._id) {
     var child = id;
@@ -348,7 +348,7 @@ MongooseArray.prototype.remove = MongooseArray.prototype.delete = function (id, 
  * @param {Function} callback
  * @api public
  */
-MongooseArray.prototype.append = function (child, callback) {
+mongooseArrayPrototype.append = function (child, callback) {
   var throwErr = function (message) {
     if (callback)
       return callback(new Error(message));
@@ -377,8 +377,8 @@ MongooseArray.prototype.append = function (child, callback) {
  * @param {Function} callback
  * @api public
  */
-var oldConcat = MongooseArray.prototype.concat;
-MongooseArray.prototype.concat = function (children, callback) {
+var oldConcat = mongooseArrayPrototype.concat;
+mongooseArrayPrototype.concat = function (children, callback) {
   if (!Array.isArray(children))
     return callback(new Error('First argument needs to be an Array'));
   var self = this, children = children.map(function (child) {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "mongo-relation",
   "description": "Model relationships plugin for Mongoose",
   "version": "0.5.5",
-  "homepage": "https://github.com/gkoberger/mongo-relation/",
+  "homepage": "https://github.com/readmeio/mongo-relation/",
   "repository": {
     "type": "git",
-    "url": "git://github.com/gkoberger/mongo-relation.git"
+    "url": "git://github.com/readmeio/mongo-relation.git"
   },
   "keywords": [
     "mongodb",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "mongo-relation",
   "description": "Model relationships plugin for Mongoose",
-  "version": "0.5.4",
-  "homepage": "https://github.com/JamesS237/mongo-relation/",
+  "version": "0.5.5",
+  "homepage": "https://github.com/gkoberger/mongo-relation/",
   "repository": {
     "type": "git",
-    "url": "git://github.com/JamesS237/mongo-relation.git"
+    "url": "git://github.com/gkoberger/mongo-relation.git"
   },
   "keywords": [
     "mongodb",


### PR DESCRIPTION
If a mongoose object is passed into mongo-relation (`.create(new Document())`) it would try to insert the full mongo object and infinitely recurse since mongoose objects have references to themselves. 

If create is called with a mongoose object `.toJSON` will be called so it can be inserted. 